### PR TITLE
load Bootstrap from cdnjs, with protocol-relative URL

### DIFF
--- a/w2s.php
+++ b/w2s.php
@@ -31,7 +31,7 @@ if(!empty($_POST['wdq'])) {
 <head>
 <meta charset="UTF-8">
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<link href="http://tools.wmflabs.org/magnustools/resources/css/bootstrap.min.css" rel="stylesheet">
+<link href="//tools-static.wmflabs.org/cdnjs/ajax/libs/twitter-bootstrap/2.3.1/css/bootstrap.min.css" rel="stylesheet">
 <title>WDQ2SPARQL</title>
 </head>
 <body style="margin: 10px">


### PR DESCRIPTION
Lots of libraries are now mirrored on Tool Labs:
https://lists.wikimedia.org/pipermail/labs-l/2015-April/003670.html
