### PR TITLE
support for WDQ ITEMS command

### DIFF
--- a/Sparql/ExactItem.php
+++ b/Sparql/ExactItem.php
@@ -1,0 +1,20 @@
+<?php
+namespace Sparql;
+
+/**
+ * For WDQ ITEMS[]
+ */
+class ExactItem extends Expression {
+  private $itemName;
+  private $id;
+
+  public function __construct( $item, $id ) {
+		$this->itemName = $item;
+		$this->id = $id;
+	}
+
+  public function emit( Syntax $syntax, $indent = "" ) {
+    return $indent . "BIND({$syntax->entityName($this->id)} as $this->itemName)\n";
+  }
+
+}

--- a/WDQ.php
+++ b/WDQ.php
@@ -18,6 +18,7 @@ use Sparql\AnyItem;
 use Sparql\Link;
 use Sparql\NoLink;
 use Sparql\GeoAround;
+use Sparql\ExactItem;
 
 /**
  * Main WDQ parser class
@@ -36,7 +37,7 @@ ExpressionPart
 		:=> Clause
 		:=> "(" Expression ")" .
 
-Clause :=> ( Claim | NoClaim | String | Between | Quantity | Tree | Web | Link | NoLink | Around ) .
+Clause :=> ( Claim | NoClaim | String | Between | Quantity | Tree | Web | Link | NoLink | Around | Items ) .
 
 Claim :=> "CLAIM[" Propvalue+"," "]" .
 
@@ -66,6 +67,8 @@ Web :=> "WEB[" Item+"," "][" PropList? "]" .
 Link :=> "LINK[" /\w+/ "]" .
 
 NoLink :=> "NOLINK[" /\w+/ "]" .
+
+Items :=> "ITEMS[" Number+"," "]" .
 
 PropList :=> Number+"," .
 
@@ -271,6 +274,12 @@ ENDG;
 				$lon = $tree->getSubnode(5)->getLeftLeaf()->getContent();
 				$radius = $tree->getSubnode(7)->getLeftLeaf()->getContent();
 				return new GeoAround($itemName, $pid, $lat, $lon, $radius);
+			case 'items':
+				$items = array();
+				foreach($tree->getSubnode(1)->findAll('Number') as $id) {
+					$items[] = new ExactItem($itemName, $id);
+				}
+				return new Union($items);
 			default:
 				throw new Exception("Unknown type {$tree->getType()}");
 		}

--- a/tests/data/wdtk/29
+++ b/tests/data/wdtk/29
@@ -1,0 +1,5 @@
+ITEMS[1]
+prefix : <http://www.wikidata.org/entity/>
+SELECT ?item WHERE {
+  BIND(:Q1 as ?item)
+}

--- a/tests/data/wdtk/30
+++ b/tests/data/wdtk/30
@@ -1,0 +1,11 @@
+ITEMS[1,2,3]
+prefix : <http://www.wikidata.org/entity/>
+SELECT ?item WHERE {
+{
+    BIND(:Q1 as ?item)
+} UNION {
+    BIND(:Q2 as ?item)
+} UNION {
+    BIND(:Q3 as ?item)
+}
+}

--- a/tests/data/wikidata/29
+++ b/tests/data/wikidata/29
@@ -1,0 +1,4 @@
+ITEMS[1]
+SELECT ?item WHERE {
+  BIND(wd:Q1 as ?item)
+}

--- a/tests/data/wikidata/30
+++ b/tests/data/wikidata/30
@@ -1,0 +1,10 @@
+ITEMS[1,2,3]
+SELECT ?item WHERE {
+{
+    BIND(wd:Q1 as ?item)
+} UNION {
+    BIND(wd:Q2 as ?item)
+} UNION {
+    BIND(wd:Q3 as ?item)
+}
+}


### PR DESCRIPTION
Adding support for the wdq ITEMS[] command, which is defined as follows on https://wdq.wmflabs.org/api_documentation.html

> `items[ITEM,...]`
> A static list of ITEMs, for example, to filter for `NOCLAIM` (which cannot be the first command). POST is recommended over GET for longer lists.
> Example: `items[1339,350]` adds items for J.S. Bach and Cambridge, UK.
> This command supports qualifiers.